### PR TITLE
Added title to each slide button

### DIFF
--- a/patternlab/source/_patterns/03-organisms/carousel/carousel.twig
+++ b/patternlab/source/_patterns/03-organisms/carousel/carousel.twig
@@ -13,8 +13,8 @@
   </div>
   <nav class="orbit-bullets">
   {% for key, slide in slides %}
-    <button data-slide="{{ key }}"{% if key == 0 %} class="is-active"{% endif %}>
-      {% if key == 0 %}<span class="show-for-sr">&nbsp;</span>{% endif %}
+    <button data-slide="{{ key }}"{% if key == 0 %} class="is-active"{% endif %} title="{{ title }} Slide {{ key + 1 }}">
+      {% if key == 0 %}<span class="show-for-sr">Current Slide</span>{% endif %}
     </button>
   {% endfor %}
   </nav>


### PR DESCRIPTION
## Description
> As a developer, I need to add a title to the slider butters for accessibility and screen readers.

## Related Tickets

* [PA11Y Issues](https://kanopi.teamwork.com/#/tasks/26886794)


## Steps to Validate
1. Visit the /component-page-test and go down to the slider
2. Inspect the slider buttons and verify the title is in the inspector
3. Verify that the active button <span> is displaying the words "Current Slide" with the "show-for-sr" class